### PR TITLE
Clean formatting baseline and public APIs

### DIFF
--- a/Sources/Luminare/Components/Composes/LuminarePickerMenu.swift
+++ b/Sources/Luminare/Components/Composes/LuminarePickerMenu.swift
@@ -10,18 +10,18 @@ import SwiftUI
 // MARK: - Picker Menu (Compose)
 
 public struct LuminarePickerMenu<Label, Option, Item>: View
-where Label: View, Option: View, Item: Hashable {
+    where Label: View, Option: View, Item: Hashable {
     @Environment(\.luminareSectionHorizontalPadding) private var horizontalPadding
-    
+
     // MARK: Fields
-    
+
     @ViewBuilder private var label: () -> Label
     @Binding private var selection: Item
     let items: [Item]
     @ViewBuilder private var itemToView: (Item) -> Option
-    
+
     // MARK: Initializers
-    
+
     public init(
         selection: Binding<Item>,
         items: [Item],
@@ -64,14 +64,14 @@ where Label: View, Option: View, Item: Hashable {
             Text(titleKey)
         }
     }
-    
+
     // MARK: Body
-    
+
     public var body: some View {
         LuminareCompose {
             HStack(spacing: 8) {
                 itemToView(selection)
-                
+
                 Image(systemName: "chevron.up.chevron.down")
                     .font(.caption2)
                     .padding(4)
@@ -116,4 +116,3 @@ where Label: View, Option: View, Item: Hashable {
     }
     .frame(width: 300)
 }
-

--- a/Sources/Luminare/Components/Form/LuminareForm.swift
+++ b/Sources/Luminare/Components/Form/LuminareForm.swift
@@ -18,11 +18,11 @@ public struct LuminareForm<Content>: View where Content: View {
     @Environment(\.luminareFormLayout) private var layout
     @Environment(\.luminareFormSpacing) private var spacing
     @Environment(\.luminareIsInsideModal) private var isInsideModal
-    
+
     @ViewBuilder private var content: () -> Content
-    
+
     @State private var luminareClickedOutside = false
-    
+
     /// Initializes a ``LuminareForm``.
     ///
     /// - Parameters:
@@ -32,7 +32,6 @@ public struct LuminareForm<Content>: View where Content: View {
     ) {
         self.content = content
     }
-
 
     public var body: some View {
         Group {
@@ -47,7 +46,7 @@ public struct LuminareForm<Content>: View where Content: View {
                     .formStyle(.luminare)
                     .clipped()
                 }
-            case let .stacked:
+            case .stacked:
                 AutoScrollView(showsIndicators: false) {
                     VStack(alignment: .leading, spacing: spacing) {
                         content()
@@ -61,8 +60,7 @@ public struct LuminareForm<Content>: View where Content: View {
         .environment(\.luminareClickedOutside, luminareClickedOutside)
         .background(content: clickedOutsideObserver)
     }
-    
-    
+
     private func clickedOutsideObserver() -> some View {
         Color.white.opacity(0.0001)
             .onTapGesture {

--- a/Sources/Luminare/Components/LuminareCompactPicker.swift
+++ b/Sources/Luminare/Components/LuminareCompactPicker.swift
@@ -213,7 +213,7 @@ private struct PickerPreview<V>: View where V: Hashable & Equatable {
     var body: some View {
         LuminareCompactPicker(selection: $selection) {
             ForEach(elements, id: \.self) { element in
-                Text("\(element)")
+                Text(verbatim: "\(element)")
             }
         }
     }

--- a/Sources/Luminare/Components/LuminareList.swift
+++ b/Sources/Luminare/Components/LuminareList.swift
@@ -218,7 +218,7 @@ public struct LuminareList<ContentA, ContentB, V, ID>: View
                 0x74, // page up
                 0x79, // page down
                 0x73, // home
-                0x77  // end
+                0x77 // end
             ]
 
             guard selectionKeyCodes.contains(event.keyCode) else {
@@ -304,39 +304,39 @@ public struct LuminareListItem<Content, V>: View
                 .environment(\.luminareItemBeingHovered, isHovering)
                 .foregroundStyle(isEnabled ? .primary : .secondary)
         }
-            .frame(height: itemHeight)
-            .contentShape(Rectangle())
-            .tag(itemValue)
-            .background {
-                if hasDividers, !isLast {
-                    VStack {
-                        Spacer()
+        .frame(height: itemHeight)
+        .contentShape(Rectangle())
+        .tag(itemValue)
+        .background {
+            if hasDividers, !isLast {
+                VStack {
+                    Spacer()
 
-                        Divider()
-                    }
-                    .padding(.trailing, -1)
+                    Divider()
                 }
+                .padding(.trailing, -1)
+            }
 
-                if isEnabled {
-                    ZStack {
-                        itemBorder()
-                            .animation(animateSelection ? animationFast : nil, value: isInSelection)
+            if isEnabled {
+                ZStack {
+                    itemBorder()
+                        .animation(animateSelection ? animationFast : nil, value: isInSelection)
 
-                        itemBackground()
-                    }
-                    .padding(.horizontal, 1)
-                    .padding(.leading, 1) // it's nuanced
+                    itemBackground()
                 }
+                .padding(.horizontal, 1)
+                .padding(.leading, 1) // it's nuanced
             }
-            .onHover { isHovering = $0 }
-            .onChange(of: selection) { _ in
-                guard isEnabled else { return }
-                updateDisplayedSelectionPart()
-            }
-            .onAppear {
-                updateDisplayedSelectionPart()
-                isHovering = false
-            }
+        }
+        .onHover { isHovering = $0 }
+        .onChange(of: selection) { _ in
+            guard isEnabled else { return }
+            updateDisplayedSelectionPart()
+        }
+        .onAppear {
+            updateDisplayedSelectionPart()
+            isHovering = false
+        }
     }
 
     private var isFirst: Bool {
@@ -608,7 +608,7 @@ private struct ListPreview<V>: View where V: Hashable & Comparable {
 
                 Button("Sort") {
                     withAnimation {
-                        items.sort(by: <)
+                        items.sort()
                     }
                 }
                 .disabled(items.isEmpty)
@@ -625,7 +625,7 @@ private struct ListPreview<V>: View where V: Hashable & Comparable {
                 selection: $selection,
                 id: \.self
             ) { value in
-                Text("\(value.wrappedValue)")
+                Text(verbatim: "\(value.wrappedValue)")
                     .contextMenu {
                         Button("Remove") {
                             if selection.isEmpty {

--- a/Sources/Luminare/Components/Section/LuminareSection.swift
+++ b/Sources/Luminare/Components/Section/LuminareSection.swift
@@ -82,7 +82,7 @@ public struct LuminareSection<Header, Content, Footer>: View where Header: View,
             } footer: {
                 wrappedFooter()
             }
-        case let .stacked:
+        case .stacked:
             VStack(alignment: .leading, spacing: 0) {
                 wrappedHeader()
 

--- a/Sources/Luminare/Utilities/Extensions/View+Extensions.swift
+++ b/Sources/Luminare/Utilities/Extensions/View+Extensions.swift
@@ -266,7 +266,7 @@ public extension View {
     }
 
     // MARK: Form
-    
+
     func luminareFormSpacing(_ spacing: CGFloat) -> some View {
         environment(\.luminareFormSpacing, spacing)
     }
@@ -400,8 +400,13 @@ public extension View {
 
     // MARK: Sidebar
 
-    func luminareSizebarOverflow(_ overflow: CGFloat) -> some View {
+    func luminareSidebarOverflow(_ overflow: CGFloat) -> some View {
         environment(\.luminareSidebarOverflow, overflow)
+    }
+
+    @available(*, deprecated, renamed: "luminareSidebarOverflow(_:)")
+    func luminareSizebarOverflow(_ overflow: CGFloat) -> some View {
+        luminareSidebarOverflow(overflow)
     }
 
     // MARK: Slider

--- a/Sources/Luminare/Window Management/Modal/LuminareModalPresentation.swift
+++ b/Sources/Luminare/Window Management/Modal/LuminareModalPresentation.swift
@@ -24,11 +24,15 @@ public enum LuminareModalPresentationAlignment: String, Equatable, Hashable,
 }
 
 public struct LuminareModalPresentation: Equatable, Hashable, Codable, Sendable {
-    let target: LuminareModalPresentationTarget
-    let alignment: LuminareModalPresentationAlignment
-    let offset: CGPoint
+    /// The coordinate space used to place the modal.
+    public let target: LuminareModalPresentationTarget
+    /// The alignment used within the target coordinate space.
+    public let alignment: LuminareModalPresentationAlignment
+    /// The offset applied after resolving the target and alignment.
+    public let offset: CGPoint
 
-    init(
+    /// Creates a modal presentation configuration.
+    public init(
         _ alignment: LuminareModalPresentationAlignment = .centered,
         offset: CGPoint = .zero,
         relativeTo target: LuminareModalPresentationTarget = .window

--- a/Sources/Luminare/Window Management/Popover/LuminarePopoverPresenter.swift
+++ b/Sources/Luminare/Window Management/Popover/LuminarePopoverPresenter.swift
@@ -285,33 +285,27 @@ public struct LuminarePopoverPresenter<Content: View>: NSViewRepresentable {
     ) -> NSRect {
         let translationAmount: CGFloat = shouldHideAnchor == true ? 4 : 0
         let anchorRect = positioningView.convert(nsView.bounds, from: nsView)
-        let baseRect: NSRect
-
-        if let attachmentAnchor {
-            baseRect = Self.alignedAnchorRect(
+        let baseRect: NSRect = if let attachmentAnchor {
+            Self.alignedAnchorRect(
                 in: anchorRect,
                 attachmentAnchor: attachmentAnchor,
                 preferredEdge: preferredEdge,
                 popoverSize: popoverSize
             )
         } else {
-            baseRect = anchorRect
+            anchorRect
         }
 
-        let translatedRect: NSRect
-
-        switch arrowEdge {
+        return switch arrowEdge {
         case .top:
-            translatedRect = baseRect.offsetBy(dx: 0, dy: translationAmount)
+            baseRect.offsetBy(dx: 0, dy: translationAmount)
         case .leading:
-            translatedRect = baseRect.offsetBy(dx: -translationAmount, dy: 0)
+            baseRect.offsetBy(dx: -translationAmount, dy: 0)
         case .bottom:
-            translatedRect = baseRect.offsetBy(dx: 0, dy: -translationAmount)
+            baseRect.offsetBy(dx: 0, dy: -translationAmount)
         case .trailing:
-            translatedRect = baseRect.offsetBy(dx: translationAmount, dy: 0)
+            baseRect.offsetBy(dx: translationAmount, dy: 0)
         }
-
-        return translatedRect
     }
 
     private static func alignedAnchorRect(

--- a/Tests/LuminareTests/PublicAPITests.swift
+++ b/Tests/LuminareTests/PublicAPITests.swift
@@ -1,0 +1,22 @@
+import Luminare
+import SwiftUI
+import Testing
+
+struct PublicAPITests {
+    @Test func modalPresentationConfigurationIsPublic() {
+        let presentation = LuminareModalPresentation(
+            .origin,
+            offset: .init(x: 12, y: 24),
+            relativeTo: .screen
+        )
+
+        #expect(presentation.target == .screen)
+        #expect(presentation.alignment == .origin)
+        #expect(presentation.offset == .init(x: 12, y: 24))
+    }
+
+    @MainActor
+    @Test func sidebarOverflowModifierIsPublic() {
+        _ = EmptyView().luminareSidebarOverflow(24)
+    }
+}


### PR DESCRIPTION
In this PR, I:
- Cleaned the SwiftFormat baseline, removed existing compiler warnings
- Corrected the sidebar overflow API spelling with a deprecated compatibility alias
- Exposes modal presentation configuration publicly

It does not introduce breaking changes.