### PR TITLE
Add macOS 26 slider tick support

### DIFF
--- a/Sources/Luminare/Components/Composes/LuminareSlider+CustomTicks.swift
+++ b/Sources/Luminare/Components/Composes/LuminareSlider+CustomTicks.swift
@@ -1,0 +1,204 @@
+//
+//  LuminareSlider+CustomTicks.swift
+//  Luminare
+//
+//  Created by KrLite on 2026/8/10.
+//
+
+import SwiftUI
+
+#if compiler(>=6.2)
+
+    // MARK: - Custom Ticks
+
+    @available(macOS 26.0, *)
+    public extension LuminareSlider {
+        /// Initializes a continuous slider with fully customizable ticks.
+        init(
+            value: Binding<V>,
+            in range: ClosedRange<V>,
+            format: F,
+            clampsUpper: Bool = true,
+            clampsLower: Bool = true,
+            onEditingChanged: @escaping (Bool) -> () = { _ in },
+            onEditingCommit: @escaping () -> () = {},
+            @SliderTickBuilder<V> ticks: () -> some SliderTickContent<V>,
+            @ViewBuilder content: @escaping (AnyView) -> Content,
+            @ViewBuilder label: @escaping () -> Label
+        ) {
+            self.init(
+                value: value,
+                in: range,
+                step: nil,
+                format: format,
+                clampsUpper: clampsUpper,
+                clampsLower: clampsLower,
+                onEditingChanged: onEditingChanged,
+                onEditingCommit: onEditingCommit,
+                sliderTickStorage: LuminareSliderTickContentStorage(ticks()),
+                content: content,
+                label: label
+            )
+        }
+
+        /// Initializes a continuous slider with a text label and fully customizable ticks.
+        @_disfavoredOverload
+        init(
+            _ title: some StringProtocol,
+            value: Binding<V>,
+            in range: ClosedRange<V>,
+            format: F,
+            clampsUpper: Bool = true,
+            clampsLower: Bool = true,
+            onEditingChanged: @escaping (Bool) -> () = { _ in },
+            onEditingCommit: @escaping () -> () = {},
+            @SliderTickBuilder<V> ticks: () -> some SliderTickContent<V>,
+            @ViewBuilder content: @escaping (AnyView) -> Content
+        ) where Label == Text {
+            self.init(
+                value: value,
+                in: range,
+                format: format,
+                clampsUpper: clampsUpper,
+                clampsLower: clampsLower,
+                onEditingChanged: onEditingChanged,
+                onEditingCommit: onEditingCommit,
+                ticks: ticks,
+                content: content
+            ) {
+                Text(title)
+            }
+        }
+
+        /// Initializes a continuous slider with a localized label and fully customizable ticks.
+        init(
+            _ titleKey: LocalizedStringKey,
+            value: Binding<V>,
+            in range: ClosedRange<V>,
+            format: F,
+            clampsUpper: Bool = true,
+            clampsLower: Bool = true,
+            onEditingChanged: @escaping (Bool) -> () = { _ in },
+            onEditingCommit: @escaping () -> () = {},
+            @SliderTickBuilder<V> ticks: () -> some SliderTickContent<V>,
+            @ViewBuilder content: @escaping (AnyView) -> Content
+        ) where Label == Text {
+            self.init(
+                value: value,
+                in: range,
+                format: format,
+                clampsUpper: clampsUpper,
+                clampsLower: clampsLower,
+                onEditingChanged: onEditingChanged,
+                onEditingCommit: onEditingCommit,
+                ticks: ticks,
+                content: content
+            ) {
+                Text(titleKey)
+            }
+        }
+
+        /// Initializes a prefixed or suffixed continuous slider with fully customizable ticks.
+        init(
+            value: Binding<V>,
+            in range: ClosedRange<V>,
+            format: F,
+            clampsUpper: Bool = true,
+            clampsLower: Bool = true,
+            prefix: Text? = nil,
+            suffix: Text? = nil,
+            onEditingChanged: @escaping (Bool) -> () = { _ in },
+            onEditingCommit: @escaping () -> () = {},
+            @SliderTickBuilder<V> ticks: () -> some SliderTickContent<V>,
+            @ViewBuilder label: @escaping () -> Label
+        ) where Content == HStack<TupleView<(Text?, AnyView, Text?)>> {
+            self.init(
+                value: value,
+                in: range,
+                format: format,
+                clampsUpper: clampsUpper,
+                clampsLower: clampsLower,
+                onEditingChanged: onEditingChanged,
+                onEditingCommit: onEditingCommit,
+                ticks: ticks
+            ) { view in
+                HStack(spacing: 0) {
+                    if let prefix {
+                        prefix
+                            .fontDesign(.monospaced)
+                    }
+
+                    view
+
+                    if let suffix {
+                        suffix
+                            .fontDesign(.monospaced)
+                    }
+                }
+            } label: {
+                label()
+            }
+        }
+
+        /// Initializes a prefixed or suffixed continuous slider with a text label and customizable ticks.
+        @_disfavoredOverload
+        init(
+            _ title: some StringProtocol,
+            value: Binding<V>,
+            in range: ClosedRange<V>,
+            format: F,
+            clampsUpper: Bool = true,
+            clampsLower: Bool = true,
+            prefix: Text? = nil,
+            suffix: Text? = nil,
+            onEditingChanged: @escaping (Bool) -> () = { _ in },
+            onEditingCommit: @escaping () -> () = {},
+            @SliderTickBuilder<V> ticks: () -> some SliderTickContent<V>
+        ) where Label == Text, Content == HStack<TupleView<(Text?, AnyView, Text?)>> {
+            self.init(
+                value: value,
+                in: range,
+                format: format,
+                clampsUpper: clampsUpper,
+                clampsLower: clampsLower,
+                prefix: prefix,
+                suffix: suffix,
+                onEditingChanged: onEditingChanged,
+                onEditingCommit: onEditingCommit,
+                ticks: ticks
+            ) {
+                Text(title)
+            }
+        }
+
+        /// Initializes a prefixed or suffixed continuous slider with a localized label and customizable ticks.
+        init(
+            _ titleKey: LocalizedStringKey,
+            value: Binding<V>,
+            in range: ClosedRange<V>,
+            format: F,
+            clampsUpper: Bool = true,
+            clampsLower: Bool = true,
+            prefix: Text? = nil,
+            suffix: Text? = nil,
+            onEditingChanged: @escaping (Bool) -> () = { _ in },
+            onEditingCommit: @escaping () -> () = {},
+            @SliderTickBuilder<V> ticks: () -> some SliderTickContent<V>
+        ) where Label == Text, Content == HStack<TupleView<(Text?, AnyView, Text?)>> {
+            self.init(
+                value: value,
+                in: range,
+                format: format,
+                clampsUpper: clampsUpper,
+                clampsLower: clampsLower,
+                prefix: prefix,
+                suffix: suffix,
+                onEditingChanged: onEditingChanged,
+                onEditingCommit: onEditingCommit,
+                ticks: ticks
+            ) {
+                Text(titleKey)
+            }
+        }
+    }
+#endif

--- a/Sources/Luminare/Components/Composes/LuminareSlider+StepTicks.swift
+++ b/Sources/Luminare/Components/Composes/LuminareSlider+StepTicks.swift
@@ -1,0 +1,215 @@
+//
+//  LuminareSlider+StepTicks.swift
+//  Luminare
+//
+//  Created by KrLite on 2026/8/10.
+//
+
+import SwiftUI
+
+#if compiler(>=6.2)
+
+    // MARK: - Stepped Ticks
+
+    @available(macOS 26.0, *)
+    public extension LuminareSlider {
+        /// Initializes a slider with a customizable tick for each step.
+        init(
+            value: Binding<V>,
+            in range: ClosedRange<V>,
+            step: V.Stride,
+            tick: @escaping (V) -> SliderTick<V>?,
+            format: F,
+            clampsUpper: Bool = true,
+            clampsLower: Bool = true,
+            onEditingChanged: @escaping (Bool) -> () = { _ in },
+            onEditingCommit: @escaping () -> () = {},
+            @ViewBuilder content: @escaping (AnyView) -> Content,
+            @ViewBuilder label: @escaping () -> Label
+        ) {
+            self.init(
+                value: value,
+                in: range,
+                step: step,
+                format: format,
+                clampsUpper: clampsUpper,
+                clampsLower: clampsLower,
+                onEditingChanged: onEditingChanged,
+                onEditingCommit: onEditingCommit,
+                sliderTickStorage: LuminareSliderStepTickStorage(body: tick),
+                content: content,
+                label: label
+            )
+        }
+
+        /// Initializes a slider with a text label and a customizable tick for each step.
+        @_disfavoredOverload
+        init(
+            _ title: some StringProtocol,
+            value: Binding<V>,
+            in range: ClosedRange<V>,
+            step: V.Stride,
+            tick: @escaping (V) -> SliderTick<V>?,
+            format: F,
+            clampsUpper: Bool = true,
+            clampsLower: Bool = true,
+            onEditingChanged: @escaping (Bool) -> () = { _ in },
+            onEditingCommit: @escaping () -> () = {},
+            @ViewBuilder content: @escaping (AnyView) -> Content
+        ) where Label == Text {
+            self.init(
+                value: value,
+                in: range,
+                step: step,
+                tick: tick,
+                format: format,
+                clampsUpper: clampsUpper,
+                clampsLower: clampsLower,
+                onEditingChanged: onEditingChanged,
+                onEditingCommit: onEditingCommit,
+                content: content
+            ) {
+                Text(title)
+            }
+        }
+
+        /// Initializes a slider with a localized label and a customizable tick for each step.
+        init(
+            _ titleKey: LocalizedStringKey,
+            value: Binding<V>,
+            in range: ClosedRange<V>,
+            step: V.Stride,
+            tick: @escaping (V) -> SliderTick<V>?,
+            format: F,
+            clampsUpper: Bool = true,
+            clampsLower: Bool = true,
+            onEditingChanged: @escaping (Bool) -> () = { _ in },
+            onEditingCommit: @escaping () -> () = {},
+            @ViewBuilder content: @escaping (AnyView) -> Content
+        ) where Label == Text {
+            self.init(
+                value: value,
+                in: range,
+                step: step,
+                tick: tick,
+                format: format,
+                clampsUpper: clampsUpper,
+                clampsLower: clampsLower,
+                onEditingChanged: onEditingChanged,
+                onEditingCommit: onEditingCommit,
+                content: content
+            ) {
+                Text(titleKey)
+            }
+        }
+
+        /// Initializes a prefixed or suffixed slider with a customizable tick for each step.
+        init(
+            value: Binding<V>,
+            in range: ClosedRange<V>,
+            step: V.Stride,
+            tick: @escaping (V) -> SliderTick<V>?,
+            format: F,
+            clampsUpper: Bool = true,
+            clampsLower: Bool = true,
+            prefix: Text? = nil,
+            suffix: Text? = nil,
+            onEditingChanged: @escaping (Bool) -> () = { _ in },
+            onEditingCommit: @escaping () -> () = {},
+            @ViewBuilder label: @escaping () -> Label
+        ) where Content == HStack<TupleView<(Text?, AnyView, Text?)>> {
+            self.init(
+                value: value,
+                in: range,
+                step: step,
+                tick: tick,
+                format: format,
+                clampsUpper: clampsUpper,
+                clampsLower: clampsLower,
+                onEditingChanged: onEditingChanged,
+                onEditingCommit: onEditingCommit
+            ) { view in
+                HStack(spacing: 0) {
+                    if let prefix {
+                        prefix
+                            .fontDesign(.monospaced)
+                    }
+
+                    view
+
+                    if let suffix {
+                        suffix
+                            .fontDesign(.monospaced)
+                    }
+                }
+            } label: {
+                label()
+            }
+        }
+
+        /// Initializes a prefixed or suffixed slider with a text label and customizable ticks.
+        @_disfavoredOverload
+        init(
+            _ title: some StringProtocol,
+            value: Binding<V>,
+            in range: ClosedRange<V>,
+            step: V.Stride,
+            tick: @escaping (V) -> SliderTick<V>?,
+            format: F,
+            clampsUpper: Bool = true,
+            clampsLower: Bool = true,
+            prefix: Text? = nil,
+            suffix: Text? = nil,
+            onEditingChanged: @escaping (Bool) -> () = { _ in },
+            onEditingCommit: @escaping () -> () = {}
+        ) where Label == Text, Content == HStack<TupleView<(Text?, AnyView, Text?)>> {
+            self.init(
+                value: value,
+                in: range,
+                step: step,
+                tick: tick,
+                format: format,
+                clampsUpper: clampsUpper,
+                clampsLower: clampsLower,
+                prefix: prefix,
+                suffix: suffix,
+                onEditingChanged: onEditingChanged,
+                onEditingCommit: onEditingCommit
+            ) {
+                Text(title)
+            }
+        }
+
+        /// Initializes a prefixed or suffixed slider with a localized label and customizable ticks.
+        init(
+            _ titleKey: LocalizedStringKey,
+            value: Binding<V>,
+            in range: ClosedRange<V>,
+            step: V.Stride,
+            tick: @escaping (V) -> SliderTick<V>?,
+            format: F,
+            clampsUpper: Bool = true,
+            clampsLower: Bool = true,
+            prefix: Text? = nil,
+            suffix: Text? = nil,
+            onEditingChanged: @escaping (Bool) -> () = { _ in },
+            onEditingCommit: @escaping () -> () = {}
+        ) where Label == Text, Content == HStack<TupleView<(Text?, AnyView, Text?)>> {
+            self.init(
+                value: value,
+                in: range,
+                step: step,
+                tick: tick,
+                format: format,
+                clampsUpper: clampsUpper,
+                clampsLower: clampsLower,
+                prefix: prefix,
+                suffix: suffix,
+                onEditingChanged: onEditingChanged,
+                onEditingCommit: onEditingCommit
+            ) {
+                Text(titleKey)
+            }
+        }
+    }
+#endif

--- a/Sources/Luminare/Components/Composes/LuminareSlider+Ticks+Previews.swift
+++ b/Sources/Luminare/Components/Composes/LuminareSlider+Ticks+Previews.swift
@@ -1,0 +1,59 @@
+//
+//  LuminareSlider+Ticks+Previews.swift
+//  Luminare
+//
+//  Created by KrLite on 2026/8/10.
+//
+
+import SwiftUI
+
+#if compiler(>=6.2)
+    #if DEBUG
+        @available(macOS 26.0, *)
+        #Preview(
+            "LuminareSlider Ticks",
+            traits: .sizeThatFitsLayout
+        ) {
+            @Previewable @State var steppedValue = 0.5
+            @Previewable @State var continuousValue = 0.5
+
+            LuminareSection {
+                LuminareSlider(
+                    "Stepped Ticks",
+                    value: $steppedValue,
+                    in: 0...1,
+                    step: 0.1,
+                    tick: { value in
+                        switch value {
+                        case 0, 0.5, 1:
+                            SliderTick(value) {
+                                Text(value, format: .number.precision(.fractionLength(0...1)))
+                            }
+                        default:
+                            SliderTick(value)
+                        }
+                    },
+                    format: .number.precision(.fractionLength(0...2))
+                )
+
+                LuminareSlider(
+                    "Custom Ticks",
+                    value: $continuousValue,
+                    in: 0...1,
+                    format: .number.precision(.fractionLength(0...2)),
+                    ticks: {
+                        SliderTickContentForEach(
+                            [0.0, 0.25, 0.5, 0.75, 1.0],
+                            id: \.self
+                        ) { value in
+                            SliderTick(value) {
+                                Text(value, format: .number.precision(.fractionLength(0...2)))
+                            }
+                        }
+                    }
+                )
+            }
+            .frame(width: 450)
+        }
+    #endif
+#endif

--- a/Sources/Luminare/Components/Composes/LuminareSlider+Ticks.swift
+++ b/Sources/Luminare/Components/Composes/LuminareSlider+Ticks.swift
@@ -1,0 +1,109 @@
+//
+//  LuminareSlider+Ticks.swift
+//  Luminare
+//
+//  Created by KrLite on 2026/8/10.
+//
+
+import SwiftUI
+
+struct LuminareNativeSlider<V>: View
+    where V: Strideable & BinaryFloatingPoint, V.Stride: BinaryFloatingPoint {
+    let value: Binding<V>
+    let range: ClosedRange<V>
+    let step: V.Stride?
+    let tickStorage: (any LuminareSliderTickStorage)?
+    let onEditingChanged: (Bool) -> ()
+
+    init(
+        value: Binding<V>,
+        in range: ClosedRange<V>,
+        step: V.Stride?,
+        tickStorage: (any LuminareSliderTickStorage)?,
+        onEditingChanged: @escaping (Bool) -> ()
+    ) {
+        self.value = value
+        self.range = range
+        self.step = step
+        self.tickStorage = tickStorage
+        self.onEditingChanged = onEditingChanged
+    }
+
+    var body: some View {
+        #if compiler(>=6.2)
+            if #available(macOS 26.0, *), let tickStorage {
+                slider(with: tickStorage)
+            } else {
+                sliderWithoutTicks
+            }
+        #else
+            sliderWithoutTicks
+        #endif
+    }
+
+    @ViewBuilder private var sliderWithoutTicks: some View {
+        if let step {
+            Slider(
+                value: value,
+                in: range,
+                step: step,
+                onEditingChanged: onEditingChanged
+            )
+        } else {
+            Slider(
+                value: value,
+                in: range,
+                onEditingChanged: onEditingChanged
+            )
+        }
+    }
+
+    #if compiler(>=6.2)
+        @available(macOS 26.0, *)
+        @ViewBuilder private func slider(with tickStorage: any LuminareSliderTickStorage) -> some View {
+            if let ticks = tickStorage as? LuminareSliderTickContentStorage<V> {
+                Slider(
+                    value: value,
+                    in: range,
+                    label: { EmptyView() },
+                    ticks: { ticks },
+                    onEditingChanged: onEditingChanged
+                )
+            } else if let step,
+                      let tick = tickStorage as? LuminareSliderStepTickStorage<V> {
+                Slider(
+                    value: value,
+                    in: range,
+                    step: step,
+                    label: { EmptyView() },
+                    tick: tick.body,
+                    onEditingChanged: onEditingChanged
+                )
+            } else {
+                sliderWithoutTicks
+            }
+        }
+    #endif
+}
+
+#if compiler(>=6.2)
+    @available(macOS 26.0, *)
+    struct LuminareSliderTickContentStorage<V>: SliderTickContent, LuminareSliderTickStorage
+        where V: BinaryFloatingPoint {
+        typealias Value = V
+        typealias Body = [SliderTick<V>]
+
+        let body: Body
+
+        init(_ content: some SliderTickContent<V>) {
+            self.body = Array(content.body)
+        }
+    }
+
+    @available(macOS 26.0, *)
+    struct LuminareSliderStepTickStorage<V>: LuminareSliderTickStorage
+        where V: BinaryFloatingPoint {
+        let body: (V) -> SliderTick<V>?
+    }
+
+#endif

--- a/Sources/Luminare/Components/Composes/LuminareSlider.swift
+++ b/Sources/Luminare/Components/Composes/LuminareSlider.swift
@@ -27,6 +27,8 @@ public extension LuminareSliderLayout {
     static var compact: Self { .compact() }
 }
 
+protocol LuminareSliderTickStorage {}
+
 // MARK: - Slider (Compose)
 
 public struct LuminareSlider<Label, Content, V, F>: View
@@ -55,6 +57,7 @@ public struct LuminareSlider<Label, Content, V, F>: View
     private let clampsUpper: Bool, clampsLower: Bool
     private let onEditingChanged: (Bool) -> ()
     private let onEditingCommit: () -> ()
+    private let sliderTickStorage: (any LuminareSliderTickStorage)?
 
     @ViewBuilder private var content: (AnyView) -> Content, label: () -> Label
 
@@ -80,6 +83,34 @@ public struct LuminareSlider<Label, Content, V, F>: View
         @ViewBuilder content: @escaping (AnyView) -> Content,
         @ViewBuilder label: @escaping () -> Label
     ) {
+        self.init(
+            value: value,
+            in: range,
+            step: step,
+            format: format,
+            clampsUpper: clampsUpper,
+            clampsLower: clampsLower,
+            onEditingChanged: onEditingChanged,
+            onEditingCommit: onEditingCommit,
+            sliderTickStorage: nil,
+            content: content,
+            label: label
+        )
+    }
+
+    init(
+        value: Binding<V>,
+        in range: ClosedRange<V>,
+        step: V.Stride?,
+        format: F,
+        clampsUpper: Bool,
+        clampsLower: Bool,
+        onEditingChanged: @escaping (Bool) -> (),
+        onEditingCommit: @escaping () -> (),
+        sliderTickStorage: (any LuminareSliderTickStorage)?,
+        @ViewBuilder content: @escaping (AnyView) -> Content,
+        @ViewBuilder label: @escaping () -> Label
+    ) {
         self._value = value
         self.internalValue = value.wrappedValue
         self.lastValue = value.wrappedValue
@@ -90,7 +121,7 @@ public struct LuminareSlider<Label, Content, V, F>: View
         self.clampsLower = clampsLower
         self.onEditingChanged = onEditingChanged
         self.onEditingCommit = onEditingCommit
-
+        self.sliderTickStorage = sliderTickStorage
         self.content = content
         self.label = label
     }
@@ -344,24 +375,13 @@ public struct LuminareSlider<Label, Content, V, F>: View
             }
         }
 
-        Group {
-            if let step {
-                Slider(
-                    value: binding,
-                    in: range,
-                    step: step
-                ) { isEditing in
-                    handleEditingChanged(isEditing)
-                }
-            } else {
-                Slider(
-                    value: binding,
-                    in: range
-                ) { isEditing in
-                    handleEditingChanged(isEditing)
-                }
-            }
-        }
+        LuminareNativeSlider(
+            value: binding,
+            in: range,
+            step: step,
+            tickStorage: sliderTickStorage,
+            onEditingChanged: handleEditingChanged
+        )
         .onHover { isSliderHovering = $0 }
     }
 

--- a/Tests/LuminareTests/LuminareSliderTickTests.swift
+++ b/Tests/LuminareTests/LuminareSliderTickTests.swift
@@ -1,0 +1,74 @@
+@testable import Luminare
+import SwiftUI
+import Testing
+
+#if compiler(>=6.2)
+    @MainActor
+    struct LuminareSliderTickTests {
+        @Test func legacyInitializerRemainsAvailable() {
+            _ = LuminareSlider(
+                "Legacy",
+                value: Binding.constant(0.5),
+                in: 0...1,
+                format: .number
+            )
+        }
+
+        @Test func customTickStoragePreservesEveryTick() {
+            if #available(macOS 26.0, *) {
+                let storage = LuminareSliderTickContentStorage(
+                    SliderTickContentForEach(
+                        [0.0, 0.5, 1.0],
+                        id: \.self
+                    ) { value in
+                        SliderTick(value)
+                    }
+                )
+
+                #expect(storage.body.count == 3)
+            }
+        }
+
+        @Test func steppedTickStorageCanOmitTicks() {
+            if #available(macOS 26.0, *) {
+                let storage = LuminareSliderStepTickStorage<Double> { value in
+                    value == 0.5 ? SliderTick(value) : nil
+                }
+
+                #expect(storage.body(0) == nil)
+                #expect(storage.body(0.5) != nil)
+                #expect(storage.body(1) == nil)
+            }
+        }
+
+        @Test func publicTickInitializersBuild() {
+            if #available(macOS 26.0, *) {
+                let value = Binding.constant(0.5)
+
+                _ = LuminareSlider(
+                    "Stepped",
+                    value: value,
+                    in: 0...1,
+                    step: 0.1,
+                    tick: { SliderTick($0) },
+                    format: .number
+                )
+
+                _ = LuminareSlider(
+                    "Continuous",
+                    value: value,
+                    in: 0...1,
+                    format: .number,
+                    ticks: {
+                        SliderTickContentForEach(
+                            [0.0, 0.5, 1.0],
+                            id: \.self
+                        ) { tickValue in
+                            SliderTick(tickValue)
+                        }
+                    }
+                )
+            }
+        }
+    }
+#endif


### PR DESCRIPTION
macOS 26 adds a new [SliderTick](https://developer.apple.com/documentation/swiftui/slidertick) API that enables custom tick markers on sliders.

This PR adds macOS 26 overloads for stepped SliderTick closures and fully customized SliderTickContent builders. Existing LuminareSlider APIs and generic parameters remain compatible.