### PR TITLE
Add focused core logic coverage

### DIFF
--- a/Tests/LuminareTests/LuminareStepperSourceTests.swift
+++ b/Tests/LuminareTests/LuminareStepperSourceTests.swift
@@ -1,0 +1,57 @@
+@testable import Luminare
+import Testing
+
+struct LuminareStepperSourceTests {
+    @Test func finiteSourceReportsItsNumericStructure() {
+        if #available(macOS 15.0, *) {
+            let source = LuminareStepperSource<Double>.finite(
+                in: -1...1,
+                step: 0.5
+            )
+
+            #expect(source.isFinite)
+            #expect(!source.isContinuous)
+            #expect(source.count == 5)
+            #expect(source.step == 0.5)
+            #expect(source.continuousIndex(of: 0.5) == 3)
+        }
+    }
+
+    @Test func finiteRoundingIsAnchoredToTheLowerBound() {
+        if #available(macOS 15.0, *) {
+            let source = LuminareStepperSource<Double>.finite(
+                in: -1...1,
+                step: 0.5
+            )
+            let result = source.round(0.76)
+
+            #expect(abs(result.value - 0.5) < 0.000_001)
+            #expect(abs(result.offset - 0.26) < 0.000_001)
+        }
+    }
+
+    @Test func finiteBoundsClampValuesAndRespectPadding() {
+        if #available(macOS 15.0, *) {
+            let source = LuminareStepperSource<Double>.finite(in: 0...10)
+
+            #expect(source.wrap(-2) == 0)
+            #expect(source.wrap(12) == 10)
+            #expect(source.wrap(5) == 5)
+            #expect(source.reachedLowerBound(0.4, padding: 0.5))
+            #expect(source.reachedUpperBound(9.6, padding: 0.5))
+        }
+    }
+
+    @Test func directionalOffsetsReverseAndOptionallyBypassClamping() {
+        if #available(macOS 15.0, *) {
+            let source = LuminareStepperSource<Double>.finite(in: 0...10)
+
+            #expect(source.offsetBy(5, direction: .horizontal, nonAlternateOffset: 2) == 7)
+            #expect(source.offsetBy(5, direction: .vertical, nonAlternateOffset: 2) == 3)
+            #expect(source.offsetBy(5, direction: .horizontalAlternate, nonAlternateOffset: 2) == 3)
+            #expect(source.offsetBy(5, direction: .verticalAlternate, nonAlternateOffset: 2) == 7)
+            #expect(source.offsetBy(9, direction: .horizontal, nonAlternateOffset: 3) == 10)
+            #expect(source.offsetBy(9, direction: .horizontal, nonAlternateOffset: 3, wrap: false) == 12)
+        }
+    }
+}

--- a/Tests/LuminareTests/StringFormatStyleTests.swift
+++ b/Tests/LuminareTests/StringFormatStyleTests.swift
@@ -1,0 +1,33 @@
+@testable import Luminare
+import SwiftUI
+import Testing
+
+struct StringFormatStyleTests {
+    @Test func identityStrategyPreservesInput() throws {
+        let style = StringFormatStyle()
+        let value = "Luminare #42ab0E"
+
+        #expect(style.format(value) == value)
+        #expect(try style.parseStrategy.parse(value) == value)
+    }
+
+    @Test func hexStrategiesNormalizeAndFilterInput() throws {
+        let value = " #42-ab:0E "
+
+        #expect(try StringFormatStyle.HexStrategy.lowercased.parse(value) == "42ab0e")
+        #expect(try StringFormatStyle.HexStrategy.uppercased.parse(value) == "42AB0E")
+        #expect(try StringFormatStyle.HexStrategy.lowercasedWithWell.parse(value) == "#42ab0e")
+        #expect(try StringFormatStyle.HexStrategy.uppercasedWithWell.parse(value) == "#42AB0E")
+    }
+
+    @Test func customHexStrategyAppliesCaseAndPrefix() throws {
+        let value = "#42ab0E"
+
+        #expect(
+            try StringFormatStyle.HexStrategy.custom(.lowercase, "$").parse(value) == "$42ab0e"
+        )
+        #expect(
+            try StringFormatStyle.HexStrategy.custom(.uppercase, "0x").parse(value) == "0x42AB0E"
+        )
+    }
+}


### PR DESCRIPTION
This PR adds a small set of high-value tests for LuminareStepperSource numeric invariants and StringFormatStyle transformations.